### PR TITLE
Allow getList to accept params

### DIFF
--- a/src/Api/Coins.php
+++ b/src/Api/Coins.php
@@ -12,9 +12,9 @@ class Coins extends Api
      * @return array
      * @throws Exception
      */
-    public function getList(): array
+    public function getList(array $params = []): array
     {
-        return $this->get('/coins/list');
+        return $this->get('/coins/list', $params);
     }
 
     /**


### PR DESCRIPTION
The official CoinGecko API accepts a `include_platform` parameter which accepts a boolean (Defaults to false) that can toggle contract addresses; https://www.coingecko.com/api/documentations/v3#/coins/get_coins_list

This commit should add the support to the call :-)

Loving what you do!